### PR TITLE
Edits to community page

### DIFF
--- a/community.md
+++ b/community.md
@@ -5,59 +5,91 @@ title: Community
 
 # Rust Community
 
-We have a great community and we want to keep it that way. Rust is
-more than just a revolutionary programming language, it is a
-tight-knit community with a [legendary dedication to kindness and
-inclusivity][techwhirl]. We are committed to providing a friendly,
-safe and welcoming environment for all, regardless of gender, sexual
-orientation, disability, ethnicity, religion, or similar personal
-characteristic. Our [code of conduct][coc] must be observed in
-all matters relating to Rust online.
+Rust has a lot going for it as a language, but its greatest strength
+is its tight-knit community and its focus on kindness and inclusivity.
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of gender, sexual orientation,
+disability, ethnicity, religion, or similar personal
+characteristic. Our [code of conduct][coc] sets the standards for
+behavior in all official Rust forums, and is upheld by the
+[moderation team][mod_team_email].
 
 [coc]: https://www.rust-lang.org/conduct.html
-[techwhirl]: http://techwhirl.com/conference-report-friendly-diverse-rust-camp/
+
+## TL;DR
+
+The most important community resources for getting started with Rust are:
+
+- The [#rust][rust_irc] IRC channel, a very friendly channel that
+  loves answering questions at any depth.
+- The [users forum][users_forum] for asynchronous discussion about all
+  things Rust.
+- The [This Week in Rust][twir] newsletter, to keep up with what's
+  happening in the community.
 
 ## News
 
-[This Week in Rust][twir]
+[This Week in Rust][twir] collects the latest news, upcoming events
+and a week-by-week account of changes in the Rust language and
+libraries.
 
-This Week in Rust contains the latest news, upcoming events and a
-week-by-week account of changes in the Rust language and libraries.
-
-[Rust Programming Blog][rust_blog]
-
-The Rust programming blog is where the Rust team makes announcements
+[The Rust Blog][rust_blog] is where the Rust team makes announcements
 about major developments.
 
-[Reddit][reddit]
+The Rust community has an [*unofficial* subreddit][reddit] where
+virtually everything happening in the Rust community is discussed.
+The forum abides by the [official code of conduct][reddit_coc].
 
-Reddit is an unofficial online forum for all things Rust.
+We also have an official [Twitter][twitter] account,
 
 [twir]: http://this-week-in-rust.org/
 [rust_blog]: http://blog.rust-lang.org/
 [reddit]: https://www.reddit.com/r/rust
+[reddit_coc]: https://www.reddit.com/r/rust/comments/2rvrzx/our_code_of_conduct_please_read/
+[twitter]: https://twitter.com/rustlang
 
 ## How to Get Help
 
-[IRC Channels][rust_irc]
+### Moderation
 
-Rustaceans primarily communicate via IRC. The
-[#rust][rust_irc] channel on Moznet is a venue for general
-discussion about Rust, and a good place to ask for help.  You'll find
+[Rust Moderation Team][mod_team]
+
+If you feel you have been or are being harassed or made uncomfortable
+by a community member, please [contact][mod_team_email] any of the
+Rust moderation team immediately. Whether you're a regular contributor
+or a newcomer, we care about making the community a safe space for
+you.
+
+[mod_team]: https://www.rust-lang.org/team.html#Moderation
+[mod_team_email]: mailto:rust-mods@googlegroups.com
+
+### IRC channels
+
+Rustaceans maintain a number of friendly, high-traffic IRC channels.
+
+The [#rust][rust_irc] channel on Moznet is a venue for general
+discussion about Rust, and a good place to ask for help. You'll find
 people willing to help you with any questions you may have, and
-responses are typically very fast. To get involved in the development
-of Rust itself, for anything about contribution, or to find a mentor,
-[#rust-internals][internals_irc] is the right channel. There are also
-some more specific IRC channels noted below.
+responses are typically very fast.
 
-IRC on Moznet
+To get involved in the development of Rust itself, for anything about
+contribution, or to find a mentor, [#rust-internals][internals_irc] is
+the right channel.
 
+There are also some more specific IRC channels
+noted below.
+
+**Core channels**:
 - [#rust][rust_irc] is for all things Rust;
 - [#rust-internals][internals_irc] is for discussion of other Rust implementation topics;
 - [#rustc][rustc_irc] is the home of the [compiler team][compiler_team];
 - [#rust-libs][libs_irc] is the home of the [libraries team][library_team];
 - [#rust-tools][tools_irc] is the home of the [tools and infrastructure team][tool_team];
 - [#rust-lang][lang_irc] is the home of the [language team][language_team];
+- [#rust-community][community_irc] is the home of the [community team][community_team];
+
+**Topical channels**:
 - [#cargo][cargo_irc] is for discussion of Cargo, Rust's package manager;
 - [#servo][servo_irc] is for discussion of Servo, the browser engine written in Rust;
 - [#rust-offtopic][offtopic_irc] is for general chit-chat amongst Rustaceans;
@@ -67,31 +99,12 @@ IRC on Moznet
 - [#rust-gamedev][gamedev_irc] is for people doing game development in Rust;
 - [#rust-bots][bots_irc] notifcations about Rust from a selection of bots.
 
-[Stack Overflow][stack_overflow]
-
-Stack Overflow is a question and answer site for programmers.
-Searching for your problem might reveal someone who has asked it
-before.
-
-[Rust Forum][forum]
-
-Rust Programming Language Forum is for general discussion and broader questions.
-
-[Twitter][twitter]
-
-[Rust Moderation Team][mod_team]
-
-If you feel you have been or are being harassed or made uncomfortable
-by a community member, please [contact][mod_team_email] any of the
-Rust moderation team immediately. Whether you're a regular contributor
-or a newcomer, we care about making this community a safe place for
-you.
-
 [rust_irc]: irc://moznet/rust
 [rustc_irc]: irc://moznet/rustc
 [libs_irc]: irc://moznet/rust-libs
 [tools_irc]: irc://moznet/rust-tools
 [lang_irc]: irc://moznet/rust-lang
+[community_irc]: irc://moznet/rust-community
 [internals_irc]: irc://moznet/rust-internals
 [gamedev_irc]: irc://moznet/rust-gamedev
 [crypto_irc]: irc://moznet/rust-crypto
@@ -101,48 +114,76 @@ you.
 [offtopic_irc]: irc://moznet/rust-offtopic
 [servo_irc]: irc://moznet/servo
 [bots_irc]: irc://moznet/rust-bots
+
+### Discourse Forums
+
+We have two forums for asynchronous discussion:
+
+- The [Users Forum][users_forum], a space for asking questions, posting code
+  snippets, talking about Rust projects, and so on.
+
+- The [Internals Forum][internals_forum], a space dedicated to design and
+  implementation discussion about Rust itself (which includes Cargo, the
+  standard library, and other core bits of infrastructure).
+
+[users_forum]: https://users.rust-lang.org/
+[internals_forum]: https://internals.rust-lang.org/
+
+### Stack Overflow
+
+[Stack Overflow][stack_overflow] is a question and answer site for programmers.
+The Rust community is fairly active on the site, so searching for your problem
+might reveal someone who has asked it before.
+
 [stack_overflow]: https://stackoverflow.com/questions/tagged/rust
-[forum]: https://users.rust-lang.org/ 
-[twitter]: https://twitter.com/rustlang
-[mod_team]: https://www.rust-lang.org/team.html#Moderation
-[mod_team_email]: mailto:rust-mods@googlegroups.com
 
-## User Groups
+## User Groups and Meetups
 
-[Rust User Groups][user_group]
+There are more than 50 [Rust User Groups][user_group] worldwide in over 20
+countries totaling over 7,000 members. Rustaceans meet periodically in Rust User
+Groups. Its a great introduction to the community and a great way to learn and
+socialize with other people with a similar interest. Meetings are usually
+monthly and very informal. Meetings are open to everyone.
 
-There are more than 50 Rust User Groups worldwide in over 20 countries
-with over 7,000 members. Rustaceans meet periodically in Rust User
-Groups.  Its a great introduction to the community and a great way to
-learn and socialize with other people with a similar interest.
-Meetings are usually monthly and very informal. Meetings are open to
-everyone.
-
-[Rust Calendar][calendar]
+There's a global [calendar][calendar] for keeping up with Rust events.
 
 [user_group]: ./user_groups.html
 [calendar]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com
 
-## People
+## The teams
 
-[Rust Teams][teams]
+Rust has a community-driven development process where most decisions are made
+through open discussion and consensus, under the stewardship of various
+[teams][teams]:
 
-Rust has a community-driven development process where most decisions
-are made through consensus, under the stewardship of a core team. The
-[Core Team][core_team] is responsible for steering the design and
-development process, overseeing the introduction of new features, and
-ultimately making decisions for which there is no consensus (this
-happens rarely). The [Language Design Team][language_team] is
-responsible for design of new language features. The [Library
-Team][library_team] is responsible for the Rust standard library,
-rust-lang crates, and conventions. The [Compiler Team][compiler_team]
-is responsible for compiler internals and optimizations. The [Tooling
-and Infrastructure Team][tool_team] is responsible for support for
-Cargo, Multirust, and CI Infrastructure. The [Community
-Team][community_team] is responsible for coordinating events,
-outreach, commercial users, teaching materials, and exposure. The
-[Moderation Team][mod_team] is responsible for helping to uphold the
+* The [Core Team][core_team] is responsible for steering the design and
+development process, overseeing the introduction of new features, and ultimately
+making decisions for which there is no consensus (this happens rarely).
+
+* The [Language Design Team][language_team] is responsible for design of new
+language features.
+
+* The [Library Team][library_team] is responsible for the Rust standard
+library, rust-lang crates, and conventions.
+
+* The [Compiler Team][compiler_team] is responsible for compiler internals and
+optimizations.
+
+* The [Tooling and Infrastructure Team][tool_team] is responsible for official
+tools like Cargo, multirust, rustfmt, as well as the CI Infrastructure for the
+project.
+
+* The [Community Team][community_team] is responsible for coordinating events,
+outreach, commercial users, teaching materials, and exposure.
+
+* The [Moderation Team][mod_team] is responsible for helping to uphold the
 [code of conduct][coc].
+
+In addition to the official team rosters, most teams also have a larger set
+of reviewers who are knowledgeable about the area and can sign off on code.
+
+If you're interested in getting involved in one of these teams, feel free to
+reach out to the team leader, who can help get you started.
 
 [teams]: https://www.rust-lang.org/team.html
 [core_team]: https://www.rust-lang.org/team.html#Core
@@ -155,35 +196,29 @@ outreach, commercial users, teaching materials, and exposure. The
 
 ## Rust Development
 
-[How to contribute][contribute]
+Rust has had over [1,200 different contributors][]authors], a number that grows
+every single week. We'd love for you to join that list! If you aren't sure what
+to work on or how to get started, take a look at our
+[how to contribute][contribute] page.
 
-According to [CodeTriage][codetriage], the Rust
-language has the most contributors of any programming language. If you
-want to join in the fun but aren't sure what to work on, please take
-a look at [how to contribute][contribute].
+As mentioned above, the [Rust Internals Forum][internals_forum] is dedicated to
+discussing the design and implementation of Rust. A lot of discussion also
+happens on Github:
 
-[Rust Internals Forum][internals]
+- The [main repository][github] and [issue tracker][issue_tracking] are the
+  front lines of the implementation work. Our reviewers strive to be friendly
+  and to help mentor newcomers, so don't hesitate to open a pull request!
 
-This is the main forum for discussing the design and implementation of
-Rust.
+- The [RFC repo][rfcs] tracks our Request for Comment process, the main pathway
+  through which the Rust community and the teams reach consensus on new
+  features proposed for the language and official libraries and tools.
 
-[Github][github]
+Roughly weekly, the Rust teams produce [team reports][team_reports] tracking
+team business, including the progression of proposals through the RFC and
+implementation process.
 
-This is where all the source code resides.
-
-[RFCs][rfcs]
-
-The RFC (request for comments) process is the main pathway through
-which the Rust community and the core team reach consensus on new
-features entering the language and standard libraries.
-
-[Team Reports][team_reports]
-
-[Issue Tracking][issue_tracking]
-
+[authors]: https://github.com/rust-lang/rust/blob/master/AUTHORS.txt
 [contribute]: ./how_to_contribute.html
-[internals]: https://internals.rust-lang.org/
-[codetriage]: http://www.codetriage.com
 [github]: https://github.com/rust-lang/rust
 [rfcs]: https://github.com/rust-lang/rfcs
 [team_reports]: https://github.com/rust-lang/subteams


### PR DESCRIPTION
Here are my suggestions for the new community page. The changes here are mostly:

- Adding a bit more structure/organization to the various sections
- Filling out a bit more material on various processes
- Toning down the level of self-congratulation :-)

Thanks again, @efindlay, for getting the ball rolling on this!